### PR TITLE
Automatically update flake.lock to the latest version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1601171649,
-        "narHash": "sha256-G3RUAi2DUq6r3ntASLS+LZC/Eamot55W1+xmBOgEh3M=",
-        "owner": "nixos",
+        "lastModified": 1619802650,
+        "narHash": "sha256-ZnQ1PWLi0N6cS6Wo8Yty6KzgrblR17oN+MB7H4lQZKA=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84d74ae9c9cbed73274b8e4e00be14688ffc93fe",
+        "rev": "7ee53c0c4fe28f81095298893c8c2fd4e7bc2886",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619978323,
-        "narHash": "sha256-Zd4sV8LTp0PBNyBBlGHd41I7oHKiHbGY1YzeaNljHJo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4e78613c0569118a7ca1f19119608bfa07dd9748",
-        "type": "github"
+        "lastModified": 1623580589,
+        "narHash": "sha256-Ayp1cjXpwFCkAiWUE46rj9APTltsiEBdIs2+cj+U7+c=",
+        "path": "/nix/store/p5d2qhw8hw4ishxpwznx2lm48jgwqb3d-source",
+        "rev": "fa0326ce5233f7d592271df52c9d0812bec47b84",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619802650,
-        "narHash": "sha256-ZnQ1PWLi0N6cS6Wo8Yty6KzgrblR17oN+MB7H4lQZKA=",
+        "lastModified": 1619808931,
+        "narHash": "sha256-GoUyxogYAE7e/Fl8onZ2mz2O70WaPcBVHJQ/NGJ98cU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ee53c0c4fe28f81095298893c8c2fd4e7bc2886",
+        "rev": "248a57d61a68fe08d9bbaa639ae3c6ea3a1bc57c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619940352,
-        "narHash": "sha256-VltZulW0khglINp11UXoDFfuCDRGmD+BSHHptarijJM=",
+        "lastModified": 1619945546,
+        "narHash": "sha256-jDQB+5iGBS0AqtT060yzQLixwNBcxNn4EOuu1bK6Pcw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd38f395de78e28c1fd812e304596dec191e3a83",
+        "rev": "c576998594b4b8790f291d17fa92d499d1dc5d42",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619945546,
-        "narHash": "sha256-jDQB+5iGBS0AqtT060yzQLixwNBcxNn4EOuu1bK6Pcw=",
+        "lastModified": 1619978323,
+        "narHash": "sha256-Zd4sV8LTp0PBNyBBlGHd41I7oHKiHbGY1YzeaNljHJo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c576998594b4b8790f291d17fa92d499d1dc5d42",
+        "rev": "4e78613c0569118a7ca1f19119608bfa07dd9748",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619808931,
-        "narHash": "sha256-GoUyxogYAE7e/Fl8onZ2mz2O70WaPcBVHJQ/NGJ98cU=",
+        "lastModified": 1619940352,
+        "narHash": "sha256-VltZulW0khglINp11UXoDFfuCDRGmD+BSHHptarijJM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "248a57d61a68fe08d9bbaa639ae3c6ea3a1bc57c",
+        "rev": "cd38f395de78e28c1fd812e304596dec191e3a83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* Updated 'nixpkgs': 'github:NixOS/nixpkgs/7ee53c0c4fe28f81095298893c8c2fd4e7bc2886' -> 'github:NixOS/nixpkgs/248a57d61a68fe08d9bbaa639ae3c6ea3a1bc57c'

---
* Updated 'nixpkgs': 'github:NixOS/nixpkgs/248a57d61a68fe08d9bbaa639ae3c6ea3a1bc57c' -> 'github:NixOS/nixpkgs/cd38f395de78e28c1fd812e304596dec191e3a83'

---
* Updated 'nixpkgs': 'github:NixOS/nixpkgs/cd38f395de78e28c1fd812e304596dec191e3a83' -> 'github:NixOS/nixpkgs/c576998594b4b8790f291d17fa92d499d1dc5d42'

---
* Updated 'nixpkgs': 'github:NixOS/nixpkgs/c576998594b4b8790f291d17fa92d499d1dc5d42' -> 'github:NixOS/nixpkgs/4e78613c0569118a7ca1f19119608bfa07dd9748'
